### PR TITLE
Fixing Sidebar attribute table Y overflow

### DIFF
--- a/app/assets/stylesheets/light_admin/components/_sidebars.scss
+++ b/app/assets/stylesheets/light_admin/components/_sidebars.scss
@@ -6,6 +6,12 @@
   label {
     margin-bottom: 5px;
   }
+
+  .attributes_table {
+    th { 
+      min-width: 0 
+    }
+  }
 }
 
 /* FILTER STATUS LIST STYLE */


### PR DESCRIPTION
### Issue

I had an Y Overflow on attribute table in sidebar
<img width="286" alt="Screenshot 2021-08-04 at 11 09 40" src="https://user-images.githubusercontent.com/2410464/128155030-076c0d5d-d778-47aa-993c-73fe1136f87f.png">

### Solution

I added a rule in the `_sidebar.scss` to disable the `min-width` on `th` contained in a sidebar.

### Result

<img width="289" alt="Screenshot 2021-08-04 at 11 09 47" src="https://user-images.githubusercontent.com/2410464/128155033-59442687-22cf-4b5f-98df-c5d69fd319ac.png">
