### PR TITLE
Update attributes_table overflow value from scroll to auto

### DIFF
--- a/app/assets/stylesheets/light_admin/components/_tables.scss
+++ b/app/assets/stylesheets/light_admin/components/_tables.scss
@@ -108,7 +108,7 @@ table.index_table {
 .attributes_table {
   border-radius: $global-border-radius;
   box-shadow: $global-shadow;
-  overflow: scroll;
+  overflow: auto;
 
   table {
     tr {


### PR DESCRIPTION
There are scroll bar on attributes_table even when it's not needed.

Change value of `overflow` from `scroll` to `auto`.