### PR TITLE
fix(ui): set up inner text of filters button to be i18n key

### DIFF
--- a/app/assets/javascripts/light_admin/filters_toggle.js.erb
+++ b/app/assets/javascripts/light_admin/filters_toggle.js.erb
@@ -1,6 +1,10 @@
 $(document).ready(function () {
   if ($("#filters_sidebar_section").length !== 0) {
-    $('#active_admin_content .table_tools').append('<a id="toggleFilters" href="#" class=\'epon\'>Filtres</a>');
+    $('#active_admin_content .table_tools').append(
+      $('<a>').text('<%= I18n.t 'active_admin.sidebars.filters' %>').attr({
+        href: '#', id:'toggleFilters', class:'epon'
+      })
+    );
   };
 
   if (!window.location.search.includes('Filter') && $('body').hasClass('index')) {


### PR DESCRIPTION
### Issue:
While application locale is set to English: 

- filters_toggle.js file:
  -  the filters button has inner text hardcoded as "Filtres", which is French.

### Fix:
This PR sets up the text of the #toggleFilters link to be the i18n key for active_admin.sidebars.filters

### Original (en locale): 
![Categories   Kiaora Rails](https://github.com/CapSens/light_admin/assets/95528250/604a3876-0d6b-4cd3-b727-005563bdaa8d)

### Fixed (en locale):
![Categories   Kiaora Rails (1)](https://github.com/CapSens/light_admin/assets/95528250/b767fccb-6b8f-4faa-aa22-bc2ae13c2bbe)
